### PR TITLE
rename openstack to opentelekomcloud

### DIFF
--- a/dns/dns.tf
+++ b/dns/dns.tf
@@ -1,13 +1,13 @@
-resource "openstack_dns_zone_v2" "dnszone" {
+resource "opentelekomcloud_dns_zone_v2" "dnszone" {
   name  = "${var.dnszone}."
   email = "email@${var.dnszone}"
   ttl   = 6000
 }
 
-resource "openstack_dns_recordset_v2" "recordset" {
-  zone_id = "${openstack_dns_zone_v2.dnszone.id}"
+resource "opentelekomcloud_dns_recordset_v2" "recordset" {
+  zone_id = "${opentelekomcloud_dns_zone_v2.dnszone.id}"
   name    = "${var.dnsname}.${var.dnszone}."
   ttl     = 3000
   type    = "A"
-  records = ["${openstack_networking_floatingip_v2.fip.*.address}"]
+  records = ["${opentelekomcloud_networking_floatingip_v2.fip.*.address}"]
 }

--- a/dns/floatingips.tf
+++ b/dns/floatingips.tf
@@ -1,4 +1,4 @@
-resource "openstack_networking_floatingip_v2" "fip" {
+resource "opentelekomcloud_networking_floatingip_v2" "fip" {
   count    = "${var.instance_count}"
   pool     = "${var.external_network}"
 }

--- a/dns/instances.tf
+++ b/dns/instances.tf
@@ -1,23 +1,23 @@
-resource "openstack_compute_instance_v2" "webserver" {
+resource "opentelekomcloud_compute_instance_v2" "webserver" {
   count           = "${var.instance_count}"
   name            = "${var.project}-webserver${format("%02d", count.index+1)}"
   image_name      = "${var.image_name}"
   flavor_name     = "${var.flavor_name}"
-  key_pair        = "${openstack_compute_keypair_v2.keypair.name}"
+  key_pair        = "${opentelekomcloud_compute_keypair_v2.keypair.name}"
   network {
-    uuid = "${openstack_networking_network_v2.network.id}"
+    uuid = "${opentelekomcloud_networking_network_v2.network.id}"
   }
-  depends_on      = ["openstack_networking_router_interface_v2.interface"]
+  depends_on      = ["opentelekomcloud_networking_router_interface_v2.interface"]
 }
 
-resource "openstack_compute_floatingip_associate_v2" "webserver_fip" {
-  floating_ip           = "${openstack_networking_floatingip_v2.fip.address}"
-  instance_id           = "${openstack_compute_instance_v2.webserver.id}"
+resource "opentelekomcloud_compute_floatingip_associate_v2" "webserver_fip" {
+  floating_ip           = "${opentelekomcloud_networking_floatingip_v2.fip.address}"
+  instance_id           = "${opentelekomcloud_compute_instance_v2.webserver.id}"
   wait_until_associated = "true"
 }
 
-resource "openstack_compute_volume_attach_v2" "volume_attach" {
+resource "opentelekomcloud_compute_volume_attach_v2" "volume_attach" {
   count       = "${var.instance_count}"
-  instance_id = "${element(openstack_compute_instance_v2.webserver.*.id, count.index)}"
-  volume_id   = "${element(openstack_blockstorage_volume_v2.volume.*.id, count.index)}"
+  instance_id = "${element(opentelekomcloud_compute_instance_v2.webserver.*.id, count.index)}"
+  volume_id   = "${element(opentelekomcloud_blockstorage_volume_v2.volume.*.id, count.index)}"
 }

--- a/dns/keypairs.tf
+++ b/dns/keypairs.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_keypair_v2" "keypair" {
+resource "opentelekomcloud_compute_keypair_v2" "keypair" {
   name       = "${var.project}-terraform_key"
   public_key = "${file("${var.ssh_pub_key}")}"
 }

--- a/dns/network.tf
+++ b/dns/network.tf
@@ -1,15 +1,15 @@
-data "openstack_networking_network_v2" "extnet" {
+data "opentelekomcloud_networking_network_v2" "extnet" {
   name = "${var.external_network}"
 }
 
-resource "openstack_networking_network_v2" "network" {
+resource "opentelekomcloud_networking_network_v2" "network" {
   name           = "${var.project}-network"
   admin_state_up = "true"
 }
 
-resource "openstack_networking_subnet_v2" "subnet" {
+resource "opentelekomcloud_networking_subnet_v2" "subnet" {
   name            = "${var.project}-subnet"
-  network_id      = "${openstack_networking_network_v2.network.id}"
+  network_id      = "${opentelekomcloud_networking_network_v2.network.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   dns_nameservers = ["8.8.8.8", "8.8.4.4"]

--- a/dns/provider.tf
+++ b/dns/provider.tf
@@ -1,4 +1,4 @@
-provider "openstack" {
+provider "opentelekomcloud" {
   user_name   = "${var.username}"
   password    = "${var.password}"
   tenant_name = "${var.tenant_name}"

--- a/dns/router.tf
+++ b/dns/router.tf
@@ -1,11 +1,11 @@
-resource "openstack_networking_router_v2" "router" {
+resource "opentelekomcloud_networking_router_v2" "router" {
   name                = "${var.project}-router"
   admin_state_up      = "true"
-  external_network_id = "${data.openstack_networking_network_v2.extnet.id}"
+  external_network_id = "${data.opentelekomcloud_networking_network_v2.extnet.id}"
 }
 
-resource "openstack_networking_router_interface_v2" "interface" {
-  router_id = "${openstack_networking_router_v2.router.id}"
-  subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+resource "opentelekomcloud_networking_router_interface_v2" "interface" {
+  router_id = "${opentelekomcloud_networking_router_v2.router.id}"
+  subnet_id = "${opentelekomcloud_networking_subnet_v2.subnet.id}"
 }
 

--- a/dns/secgroups.tf
+++ b/dns/secgroups.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_secgroup_v2" "secgrp_web" {
+resource "opentelekomcloud_compute_secgroup_v2" "secgrp_web" {
   name        = "${var.project}-secgrp-web"
   description = "Webserver Security Group"
 

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -1,4 +1,4 @@
-### OpenStack Credentials
+### opentelekomcloud Credentials
 variable "username" {}
 
 variable "password" {}

--- a/dns/volumes.tf
+++ b/dns/volumes.tf
@@ -1,4 +1,4 @@
-resource "openstack_blockstorage_volume_v2" "volume" {
+resource "opentelekomcloud_blockstorage_volume_v2" "volume" {
   count = "${var.instance_count}"
   name  = "${var.project}-disk${format("%02d", count.index+1)}"
   size  = "${var.disk_size_gb}" 

--- a/full/dns.tf
+++ b/full/dns.tf
@@ -1,15 +1,15 @@
-resource "openstack_dns_zone_v2" "dnszone" {
+resource "opentelekomcloud_dns_zone_v2" "dnszone" {
   count = "${var.dnszone != "" ? 1 : 0}"
   name  = "${var.dnszone}."
   email = "email@${var.dnszone}"
   ttl   = 6000
 }
 
-resource "openstack_dns_recordset_v2" "recordset" {
+resource "opentelekomcloud_dns_recordset_v2" "recordset" {
   count   = "${var.dnszone != "" ? 1 : 0}"
-  zone_id = "${openstack_dns_zone_v2.dnszone.id}"
+  zone_id = "${opentelekomcloud_dns_zone_v2.dnszone.id}"
   name    = "${var.dnsname}.${var.dnszone}."
   ttl     = 3000
   type    = "A"
-  records = ["${openstack_networking_floatingip_v2.fip.*.address}"]
+  records = ["${opentelekomcloud_networking_floatingip_v2.fip.*.address}"]
 }

--- a/full/floatingips.tf
+++ b/full/floatingips.tf
@@ -1,4 +1,4 @@
-resource "openstack_networking_floatingip_v2" "fip" {
+resource "opentelekomcloud_networking_floatingip_v2" "fip" {
   pool    = "${var.external_network}"
-  port_id = "${openstack_lb_loadbalancer_v2.loadbalancer.vip_port_id}"
+  port_id = "${opentelekomcloud_lb_loadbalancer_v2.loadbalancer.vip_port_id}"
 }

--- a/full/instances.tf
+++ b/full/instances.tf
@@ -1,21 +1,21 @@
-resource "openstack_compute_instance_v2" "webserver" {
+resource "opentelekomcloud_compute_instance_v2" "webserver" {
   count           = "${var.instance_count}"
   name            = "${var.project}-webserver${format("%02d", count.index+1)}"
   image_name      = "${var.image_name}"
   flavor_name     = "${var.flavor_name}"
-  key_pair        = "${openstack_compute_keypair_v2.keypair.name}"
+  key_pair        = "${opentelekomcloud_compute_keypair_v2.keypair.name}"
   user_data       = "${data.template_file.webserver.rendered}"
   security_groups = [
-    "${openstack_compute_secgroup_v2.secgrp_web.name}"
+    "${opentelekomcloud_compute_secgroup_v2.secgrp_web.name}"
   ]
 
   network {
-    uuid          = "${openstack_networking_network_v2.network.id}"
+    uuid          = "${opentelekomcloud_networking_network_v2.network.id}"
   }
 }
 
-resource "openstack_compute_volume_attach_v2" "volume_attach" {
+resource "opentelekomcloud_compute_volume_attach_v2" "volume_attach" {
   count       = "${var.disk_size_gb > 0 ? var.instance_count : 0}"
-  instance_id = "${element(openstack_compute_instance_v2.webserver.*.id, count.index)}"
-  volume_id   = "${element(openstack_blockstorage_volume_v2.volume.*.id, count.index)}"
+  instance_id = "${element(opentelekomcloud_compute_instance_v2.webserver.*.id, count.index)}"
+  volume_id   = "${element(opentelekomcloud_blockstorage_volume_v2.volume.*.id, count.index)}"
 }

--- a/full/keypairs.tf
+++ b/full/keypairs.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_keypair_v2" "keypair" {
+resource "opentelekomcloud_compute_keypair_v2" "keypair" {
   name       = "${var.project}-terraform_key"
   public_key = "${file("${var.ssh_pub_key}")}"
 }

--- a/full/loadbalancer.tf
+++ b/full/loadbalancer.tf
@@ -1,35 +1,35 @@
-resource "openstack_lb_loadbalancer_v2" "loadbalancer" {
+resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer" {
   name           = "${var.project}-loadbalancer"
-  vip_subnet_id  = "${openstack_networking_subnet_v2.subnet.id}"
+  vip_subnet_id  = "${opentelekomcloud_networking_subnet_v2.subnet.id}"
   admin_state_up = "true"
-  depends_on     = ["openstack_networking_router_interface_v2.interface"]
+  depends_on     = ["opentelekomcloud_networking_router_interface_v2.interface"]
 }
 
-resource "openstack_lb_listener_v2" "listener" {
+resource "opentelekomcloud_lb_listener_v2" "listener" {
   name             = "${var.project}-listener"
   protocol         = "HTTP"
   protocol_port    = 80
-  loadbalancer_id  = "${openstack_lb_loadbalancer_v2.loadbalancer.id}"
+  loadbalancer_id  = "${opentelekomcloud_lb_loadbalancer_v2.loadbalancer.id}"
   admin_state_up   = "true"
   connection_limit = "-1"
 }
 
-resource "openstack_lb_pool_v2" "pool" {
+resource "opentelekomcloud_lb_pool_v2" "pool" {
   protocol    = "HTTP"
   lb_method   = "ROUND_ROBIN"
-  listener_id = "${openstack_lb_listener_v2.listener.id}"
+  listener_id = "${opentelekomcloud_lb_listener_v2.listener.id}"
 }
 
-resource "openstack_lb_member_v2" "member" {
+resource "opentelekomcloud_lb_member_v2" "member" {
   count         = "${var.instance_count}"
-  address       = "${element(openstack_compute_instance_v2.webserver.*.access_ip_v4, count.index)}"
-  pool_id       = "${openstack_lb_pool_v2.pool.id}"
-  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  address       = "${element(opentelekomcloud_compute_instance_v2.webserver.*.access_ip_v4, count.index)}"
+  pool_id       = "${opentelekomcloud_lb_pool_v2.pool.id}"
+  subnet_id     = "${opentelekomcloud_networking_subnet_v2.subnet.id}"
   protocol_port = 80
 }
 
-resource "openstack_lb_monitor_v2" "monitor" {
-  pool_id        = "${openstack_lb_pool_v2.pool.id}"
+resource "opentelekomcloud_lb_monitor_v2" "monitor" {
+  pool_id        = "${opentelekomcloud_lb_pool_v2.pool.id}"
   type           = "HTTP"
   url_path       = "/"
   expected_codes = "200"

--- a/full/network.tf
+++ b/full/network.tf
@@ -1,15 +1,15 @@
-data "openstack_networking_network_v2" "extnet" {
+data "opentelekomcloud_networking_network_v2" "extnet" {
   name = "${var.external_network}"
 }
 
-resource "openstack_networking_network_v2" "network" {
+resource "opentelekomcloud_networking_network_v2" "network" {
   name           = "${var.project}-network"
   admin_state_up = "true"
 }
 
-resource "openstack_networking_subnet_v2" "subnet" {
+resource "opentelekomcloud_networking_subnet_v2" "subnet" {
   name            = "${var.project}-subnet"
-  network_id      = "${openstack_networking_network_v2.network.id}"
+  network_id      = "${opentelekomcloud_networking_network_v2.network.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   dns_nameservers = ["8.8.8.8", "8.8.4.4"]

--- a/full/provider.tf
+++ b/full/provider.tf
@@ -1,4 +1,4 @@
-provider "openstack" {
+provider "opentelekomcloud" {
   user_name   = "${var.username}"
   password    = "${var.password}"
   tenant_name = "${var.tenant_name}"

--- a/full/router.tf
+++ b/full/router.tf
@@ -1,11 +1,11 @@
-resource "openstack_networking_router_v2" "router" {
+resource "opentelekomcloud_networking_router_v2" "router" {
   name                = "${var.project}-router"
   admin_state_up      = "true"
-  external_network_id = "${data.openstack_networking_network_v2.extnet.id}"
+  external_network_id = "${data.opentelekomcloud_networking_network_v2.extnet.id}"
 }
 
-resource "openstack_networking_router_interface_v2" "interface" {
-  router_id = "${openstack_networking_router_v2.router.id}"
-  subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+resource "opentelekomcloud_networking_router_interface_v2" "interface" {
+  router_id = "${opentelekomcloud_networking_router_v2.router.id}"
+  subnet_id = "${opentelekomcloud_networking_subnet_v2.subnet.id}"
 }
 

--- a/full/secgroups.tf
+++ b/full/secgroups.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_secgroup_v2" "secgrp_web" {
+resource "opentelekomcloud_compute_secgroup_v2" "secgrp_web" {
   name        = "${var.project}-secgrp-web"
   description = "Webserver Security Group"
 

--- a/full/variables.tf
+++ b/full/variables.tf
@@ -1,4 +1,4 @@
-### OpenStack Credentials
+### opentelekomcloud Credentials
 variable "username" {}
 
 variable "password" {}

--- a/full/volumes.tf
+++ b/full/volumes.tf
@@ -1,4 +1,4 @@
-resource "openstack_blockstorage_volume_v2" "volume" {
+resource "opentelekomcloud_blockstorage_volume_v2" "volume" {
   count = "${var.disk_size_gb > 0 ? var.instance_count : 0}"
   name  = "${var.project}-disk${format("%02d", count.index+1)}"
   size  = "${var.disk_size_gb}" 

--- a/minimal/floatingips.tf
+++ b/minimal/floatingips.tf
@@ -1,4 +1,4 @@
-resource "openstack_networking_floatingip_v2" "fip" {
+resource "opentelekomcloud_networking_floatingip_v2" "fip" {
   count    = "${var.instance_count}"
   pool     = "${var.external_network}"
 }

--- a/minimal/instances.tf
+++ b/minimal/instances.tf
@@ -1,21 +1,21 @@
-resource "openstack_compute_instance_v2" "webserver" {
+resource "opentelekomcloud_compute_instance_v2" "webserver" {
   count           = "${var.instance_count}"
   name            = "${var.project}-webserver${format("%02d", count.index+1)}"
   image_name      = "${var.image_name}"
   flavor_name     = "${var.flavor_name}"
-  key_pair        = "${openstack_compute_keypair_v2.keypair.name}"
+  key_pair        = "${opentelekomcloud_compute_keypair_v2.keypair.name}"
   security_groups = [
-    "${openstack_compute_secgroup_v2.secgrp_web.name}"
+    "${opentelekomcloud_compute_secgroup_v2.secgrp_web.name}"
   ]
 
   network {
-    uuid = "${openstack_networking_network_v2.network.id}"
+    uuid = "${opentelekomcloud_networking_network_v2.network.id}"
   }
-  depends_on      = ["openstack_networking_router_interface_v2.interface"]
+  depends_on      = ["opentelekomcloud_networking_router_interface_v2.interface"]
 }
 
-resource "openstack_compute_floatingip_associate_v2" "webserver_fip" {
-  floating_ip           = "${openstack_networking_floatingip_v2.fip.address}"
-  instance_id           = "${openstack_compute_instance_v2.webserver.id}"
+resource "opentelekomcloud_compute_floatingip_associate_v2" "webserver_fip" {
+  floating_ip           = "${opentelekomcloud_networking_floatingip_v2.fip.address}"
+  instance_id           = "${opentelekomcloud_compute_instance_v2.webserver.id}"
   wait_until_associated = "true"
 }

--- a/minimal/keypairs.tf
+++ b/minimal/keypairs.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_keypair_v2" "keypair" {
+resource "opentelekomcloud_compute_keypair_v2" "keypair" {
   name       = "${var.project}-terraform_key"
   public_key = "${file("${var.ssh_pub_key}")}"
 }

--- a/minimal/network.tf
+++ b/minimal/network.tf
@@ -1,15 +1,15 @@
-data "openstack_networking_network_v2" "extnet" {
+data "opentelekomcloud_networking_network_v2" "extnet" {
   name = "${var.external_network}"
 }
 
-resource "openstack_networking_network_v2" "network" {
+resource "opentelekomcloud_networking_network_v2" "network" {
   name           = "${var.project}-network"
   admin_state_up = "true"
 }
 
-resource "openstack_networking_subnet_v2" "subnet" {
+resource "opentelekomcloud_networking_subnet_v2" "subnet" {
   name            = "${var.project}-subnet"
-  network_id      = "${openstack_networking_network_v2.network.id}"
+  network_id      = "${opentelekomcloud_networking_network_v2.network.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   dns_nameservers = ["8.8.8.8", "8.8.4.4"]

--- a/minimal/provider.tf
+++ b/minimal/provider.tf
@@ -1,4 +1,4 @@
-provider "openstack" {
+provider "opentelekomcloud" {
   user_name   = "${var.username}"
   password    = "${var.password}"
   tenant_name = "${var.tenant_name}"

--- a/minimal/router.tf
+++ b/minimal/router.tf
@@ -1,11 +1,11 @@
-resource "openstack_networking_router_v2" "router" {
+resource "opentelekomcloud_networking_router_v2" "router" {
   name                = "${var.project}-router"
   admin_state_up      = "true"
-  external_network_id = "${data.openstack_networking_network_v2.extnet.id}"
+  external_network_id = "${data.opentelekomcloud_networking_network_v2.extnet.id}"
 }
 
-resource "openstack_networking_router_interface_v2" "interface" {
-  router_id = "${openstack_networking_router_v2.router.id}"
-  subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+resource "opentelekomcloud_networking_router_interface_v2" "interface" {
+  router_id = "${opentelekomcloud_networking_router_v2.router.id}"
+  subnet_id = "${opentelekomcloud_networking_subnet_v2.subnet.id}"
 }
 

--- a/minimal/secgroups.tf
+++ b/minimal/secgroups.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_secgroup_v2" "secgrp_web" {
+resource "opentelekomcloud_compute_secgroup_v2" "secgrp_web" {
   name        = "${var.project}-secgrp-web"
   description = "Webserver Security Group"
 

--- a/minimal/variables.tf
+++ b/minimal/variables.tf
@@ -1,4 +1,4 @@
-### OpenStack Credentials
+### opentelekomcloud Credentials
 variable "username" {}
 
 variable "password" {}

--- a/modules/provider.tf
+++ b/modules/provider.tf
@@ -1,4 +1,4 @@
-provider "openstack" {
+provider "opentelekomcloud" {
   user_name   = "${var.username}"
   password    = "${var.password}"
   tenant_name = "${var.tenant_name}"

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -1,4 +1,4 @@
-### OpenStack Credentials
+### opentelekomcloud Credentials
 variable "username" {}
 
 variable "password" {}

--- a/provisioner/floatingips.tf
+++ b/provisioner/floatingips.tf
@@ -1,4 +1,4 @@
-resource "openstack_networking_floatingip_v2" "fip" {
+resource "opentelekomcloud_networking_floatingip_v2" "fip" {
   count    = "${var.instance_count}"
   pool     = "${var.external_network}"
 }

--- a/provisioner/instances.tf
+++ b/provisioner/instances.tf
@@ -1,33 +1,33 @@
-resource "openstack_compute_instance_v2" "webserver" {
+resource "opentelekomcloud_compute_instance_v2" "webserver" {
   count          = "${var.instance_count}"
   name           = "${var.project}-webserver${format("%02d", count.index+1)}"
   image_name     = "${var.image_name}"
   flavor_name    = "${var.flavor_name}"
-  key_pair       = "${openstack_compute_keypair_v2.keypair.name}"
+  key_pair       = "${opentelekomcloud_compute_keypair_v2.keypair.name}"
   user_data      = "${data.template_file.webserver.rendered}"
-  depends_on     = ["openstack_networking_router_interface_v2.interface"]
+  depends_on     = ["opentelekomcloud_networking_router_interface_v2.interface"]
   security_groups = [
-    "${openstack_compute_secgroup_v2.secgrp_web.name}"
+    "${opentelekomcloud_compute_secgroup_v2.secgrp_web.name}"
   ]
 
   network {
-    uuid = "${openstack_networking_network_v2.network.id}"
+    uuid = "${opentelekomcloud_networking_network_v2.network.id}"
   }
 }
 
-resource "openstack_compute_floatingip_associate_v2" "webserver_fip" {
-  floating_ip           = "${openstack_networking_floatingip_v2.fip.address}"
-  instance_id           = "${openstack_compute_instance_v2.webserver.id}"
+resource "opentelekomcloud_compute_floatingip_associate_v2" "webserver_fip" {
+  floating_ip           = "${opentelekomcloud_networking_floatingip_v2.fip.address}"
+  instance_id           = "${opentelekomcloud_compute_instance_v2.webserver.id}"
   wait_until_associated = "true"
 }
 
 resource "null_resource" "provision" {
-  depends_on = ["openstack_compute_instance_v2.webserver"]
+  depends_on = ["opentelekomcloud_compute_instance_v2.webserver"]
 
   connection {
     type        = "ssh"
     user        = "${var.ssh_user}"
-    host        = "${openstack_networking_floatingip_v2.fip.address}"
+    host        = "${opentelekomcloud_networking_floatingip_v2.fip.address}"
     # private_key = "${file("${var.ssh_priv_key}")}" works only for unencrypted private keys
     agent       = "true"
   }

--- a/provisioner/keypairs.tf
+++ b/provisioner/keypairs.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_keypair_v2" "keypair" {
+resource "opentelekomcloud_compute_keypair_v2" "keypair" {
   name       = "${var.project}-terraform_key"
   public_key = "${file("${var.ssh_pub_key}")}"
 }

--- a/provisioner/network.tf
+++ b/provisioner/network.tf
@@ -1,15 +1,15 @@
-data "openstack_networking_network_v2" "extnet" {
+data "opentelekomcloud_networking_network_v2" "extnet" {
   name = "${var.external_network}"
 }
 
-resource "openstack_networking_network_v2" "network" {
+resource "opentelekomcloud_networking_network_v2" "network" {
   name           = "${var.project}-network"
   admin_state_up = "true"
 }
 
-resource "openstack_networking_subnet_v2" "subnet" {
+resource "opentelekomcloud_networking_subnet_v2" "subnet" {
   name            = "${var.project}-subnet"
-  network_id      = "${openstack_networking_network_v2.network.id}"
+  network_id      = "${opentelekomcloud_networking_network_v2.network.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   dns_nameservers = ["8.8.8.8", "8.8.4.4"]

--- a/provisioner/provider.tf
+++ b/provisioner/provider.tf
@@ -1,4 +1,4 @@
-provider "openstack" {
+provider "opentelekomcloud" {
   user_name   = "${var.username}"
   password    = "${var.password}"
   tenant_name = "${var.tenant_name}"

--- a/provisioner/router.tf
+++ b/provisioner/router.tf
@@ -1,11 +1,11 @@
-resource "openstack_networking_router_v2" "router" {
+resource "opentelekomcloud_networking_router_v2" "router" {
   name                = "${var.project}-router"
   admin_state_up      = "true"
-  external_network_id = "${data.openstack_networking_network_v2.extnet.id}"
+  external_network_id = "${data.opentelekomcloud_networking_network_v2.extnet.id}"
 }
 
-resource "openstack_networking_router_interface_v2" "interface" {
-  router_id = "${openstack_networking_router_v2.router.id}"
-  subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+resource "opentelekomcloud_networking_router_interface_v2" "interface" {
+  router_id = "${opentelekomcloud_networking_router_v2.router.id}"
+  subnet_id = "${opentelekomcloud_networking_subnet_v2.subnet.id}"
 }
 

--- a/provisioner/secgroups.tf
+++ b/provisioner/secgroups.tf
@@ -1,4 +1,4 @@
-resource "openstack_compute_secgroup_v2" "secgrp_web" {
+resource "opentelekomcloud_compute_secgroup_v2" "secgrp_web" {
   name        = "${var.project}-secgrp-web"
   description = "Webserver Security Group"
 

--- a/provisioner/variables.tf
+++ b/provisioner/variables.tf
@@ -1,4 +1,4 @@
-### OpenStack Credentials
+### opentelekomcloud Credentials
 variable "username" {}
 
 variable "password" {}


### PR DESCRIPTION
This update uses the namespace of opentelekomcloud instead of the openstack.
According to the documentation in the terraform site, this is how it should be.
